### PR TITLE
Make LocalProcessManager portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 1.1.0
+
+* Added support to transparently find the right executable under Windows.
+
 #### 1.0.1
 
 * The `executable` and `arguments` parameters have been merged into one

--- a/lib/src/interface/common.dart
+++ b/lib/src/interface/common.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io' show File, Directory;
+
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
+
+/// Searches the `PATH` for the actual executable that [commandName] is supposed
+/// to launch.
+///
+/// Return `null` if the executable cannot be found.
+@visibleForTesting
+String getExecutablePath(String commandName, String workingDirectory,
+    {Platform platform}) {
+  platform ??= new LocalPlatform();
+  workingDirectory ??= Directory.current.path;
+  // TODO(goderbauer): refactor when github.com/google/platform.dart/issues/2
+  //     is available.
+  String pathSeparator = platform.isWindows ? ';' : ':';
+
+  List<String> extensions = <String>[];
+  if (platform.isWindows && p.extension(commandName).isEmpty) {
+    extensions = platform.environment['PATHEXT'].split(pathSeparator);
+  }
+
+  List<String> candidates = <String>[];
+  if (commandName.contains(p.separator)) {
+    candidates =
+        _getCandidatePaths(commandName, <String>[workingDirectory], extensions);
+  } else {
+    List<String> searchPath = platform.environment['PATH'].split(pathSeparator);
+    candidates = _getCandidatePaths(commandName, searchPath, extensions);
+  }
+  return candidates.firstWhere((String path) => new File(path).existsSync(),
+      orElse: () => null);
+}
+
+/// Returns all possible combinations of `$searchPath\$commandName.$ext` for
+/// `searchPath` in [searchPaths] and `ext` in [extensions].
+///
+/// If [extensions] is empty, it will just enumerate all
+/// `$searchPath\$commandName`.
+/// If [commandName] is an absolute path, it will just enumerate
+/// `$commandName.$ext`.
+Iterable<String> _getCandidatePaths(
+    String commandName, List<String> searchPaths, List<String> extensions) {
+  List<String> withExtensions = extensions.isNotEmpty
+      ? extensions.map((String ext) => '$commandName$ext').toList()
+      : <String>[commandName];
+  if (p.isAbsolute(commandName)) {
+    return withExtensions;
+  }
+  return searchPaths
+      .map((String path) =>
+          withExtensions.map((String command) => p.join(path, command)))
+      .expand((Iterable<String> e) => e)
+      .toList();
+}

--- a/lib/src/interface/process_manager.dart
+++ b/lib/src/interface/process_manager.dart
@@ -163,6 +163,9 @@ abstract class ProcessManager {
     Encoding stderrEncoding: SYSTEM_ENCODING,
   });
 
+  /// Returns `true` if the [executable] exists and if it can be executed.
+  bool canRun(dynamic executable, {String workingDirectory});
+
   /// Kills the process with id [pid].
   ///
   /// Where possible, sends the [signal] to the process with id

--- a/lib/src/record_replay/can_run_manifest_entry.dart
+++ b/lib/src/record_replay/can_run_manifest_entry.dart
@@ -1,0 +1,36 @@
+import 'manifest_entry.dart';
+
+/// An entry in the process invocation manifest for `canRun`.
+class CanRunManifestEntry extends ManifestEntry {
+  @override
+  final String type = 'can_run';
+
+  /// The name of the executable for which the run-ability is checked.
+  final String executable;
+
+  /// The result of the check.
+  final bool result;
+
+  /// Creates a new manifest entry with the given properties.
+  CanRunManifestEntry({this.executable, this.result});
+
+  /// Creates a new manifest entry populated with the specified JSON [data].
+  ///
+  /// If any required fields are missing from the JSON data, this will throw
+  /// a [FormatException].
+  factory CanRunManifestEntry.fromJson(Map<String, dynamic> data) {
+    checkRequiredField(data, 'executable');
+    checkRequiredField(data, 'result');
+    CanRunManifestEntry entry = new CanRunManifestEntry(
+      executable: data['executable'],
+      result: data['result'],
+    );
+    return entry;
+  }
+
+  @override
+  Map<String, dynamic> toJson() => new JsonBuilder()
+      .add('executable', executable)
+      .add('result', result)
+      .entry;
+}

--- a/lib/src/record_replay/manifest_entry.dart
+++ b/lib/src/record_replay/manifest_entry.dart
@@ -1,140 +1,11 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
-import 'dart:convert';
-import 'dart:io' show ProcessStartMode, SYSTEM_ENCODING;
-
 import 'manifest.dart';
 import 'replay_process_manager.dart';
-
-/// Throws a [FormatException] if [data] does not contain [key].
-void _checkRequiredField(Map<String, dynamic> data, String key) {
-  if (!data.containsKey(key))
-    throw new FormatException('Required field missing: $key');
-}
-
-/// Gets a `ProcessStartMode` value by its string name.
-ProcessStartMode _getProcessStartMode(String value) {
-  if (value != null) {
-    for (ProcessStartMode mode in ProcessStartMode.values) {
-      if (mode.toString() == value) {
-        return mode;
-      }
-    }
-    throw new FormatException('Invalid value for mode: $value');
-  }
-  return null;
-}
-
-/// Gets an `Encoding` instance by the encoding name.
-Encoding _getEncoding(String encoding) {
-  if (encoding == 'system') {
-    return SYSTEM_ENCODING;
-  } else if (encoding != null) {
-    return Encoding.getByName(encoding);
-  }
-  return null;
-}
 
 /// An entry in the process invocation manifest.
 ///
 /// Each entry in the [Manifest] represents a single recorded process
 /// invocation.
-class ManifestEntry {
-  /// The process id.
-  final int pid;
-
-  /// The base file name for this entry. `stdout` and `stderr` files for this
-  /// process will be serialized in the recording directory as
-  /// `$basename.stdout` and `$basename.stderr`, respectively.
-  final String basename;
-
-  /// The command that was run. The first element is the executable, and the
-  /// remaining elements are the arguments to the executable.
-  final List<String> command;
-
-  /// The process' working directory when it was spawned.
-  final String workingDirectory;
-
-  /// The environment variables that were passed to the process.
-  final Map<String, String> environment;
-
-  /// Whether the invoker's environment was made available to the process.
-  final bool includeParentEnvironment;
-
-  /// Whether the process was spawned through a system shell.
-  final bool runInShell;
-
-  /// The mode with which the process was spawned.
-  final ProcessStartMode mode;
-
-  /// The encoding used for the `stdout` of the process.
-  final Encoding stdoutEncoding;
-
-  /// The encoding used for the `stderr` of the process.
-  final Encoding stderrEncoding;
-
-  /// The exit code of the process.
-  int exitCode;
-
-  /// Creates a new manifest entry with the given properties.
-  ManifestEntry({
-    this.pid,
-    this.basename,
-    this.command,
-    this.workingDirectory,
-    this.environment,
-    this.includeParentEnvironment,
-    this.runInShell,
-    this.mode,
-    this.stdoutEncoding,
-    this.stderrEncoding,
-    this.exitCode,
-  });
-
-  /// Creates a new manifest entry populated with the specified JSON [data].
-  ///
-  /// If any required fields are missing from the JSON data, this will throw
-  /// a [FormatException].
-  factory ManifestEntry.fromJson(Map<String, dynamic> data) {
-    _checkRequiredField(data, 'pid');
-    _checkRequiredField(data, 'basename');
-    _checkRequiredField(data, 'command');
-    ManifestEntry entry = new ManifestEntry(
-      pid: data['pid'],
-      basename: data['basename'],
-      command: data['command'],
-      workingDirectory: data['workingDirectory'],
-      environment: data['environment'],
-      includeParentEnvironment: data['includeParentEnvironment'],
-      runInShell: data['runInShell'],
-      mode: _getProcessStartMode(data['mode']),
-      stdoutEncoding: _getEncoding(data['stdoutEncoding']),
-      stderrEncoding: _getEncoding(data['stderrEncoding']),
-      exitCode: data['exitCode'],
-    );
-    entry.daemon = data['daemon'];
-    entry.notResponding = data['notResponding'];
-    return entry;
-  }
-
-  /// The executable that was invoked.
-  String get executable => command.first;
-
-  /// The arguments that were passed to [executable].
-  List<String> get arguments => command.skip(1).toList();
-
-  /// Indicates that the process is a daemon.
-  bool get daemon => _daemon;
-  bool _daemon = false;
-  set daemon(bool value) => _daemon = value ?? false;
-
-  /// Indicates that the process did not respond to `SIGTERM`.
-  bool get notResponding => _notResponding;
-  bool _notResponding = false;
-  set notResponding(bool value) => _notResponding = value ?? false;
-
+abstract class ManifestEntry {
   /// Whether this entry has been "invoked" by [ReplayProcessManager].
   bool get invoked => _invoked;
   bool _invoked = false;
@@ -144,36 +15,32 @@ class ManifestEntry {
     _invoked = true;
   }
 
+  /// The type of this [ManifestEntry].
+  String get type;
+
   /// Returns a JSON-encodable representation of this manifest entry.
-  Map<String, dynamic> toJson() => new _JsonBuilder()
-      .add('pid', pid)
-      .add('basename', basename)
-      .add('command', command)
-      .add('workingDirectory', workingDirectory)
-      .add('environment', environment)
-      .add('includeParentEnvironment', includeParentEnvironment)
-      .add('runInShell', runInShell)
-      .add('mode', mode, () => mode.toString())
-      .add('stdoutEncoding', stdoutEncoding, () => stdoutEncoding.name)
-      .add('stderrEncoding', stderrEncoding, () => stderrEncoding.name)
-      .add('daemon', daemon)
-      .add('notResponding', notResponding)
-      .add('exitCode', exitCode)
-      .entry;
+  Map<String, dynamic> toJson();
 }
 
 /// A lightweight class that provides a means of building a manifest entry
 /// JSON object.
-class _JsonBuilder {
+class JsonBuilder {
+  /// The JSON-encodable object.
   final Map<String, dynamic> entry = <String, dynamic>{};
 
   /// Adds the specified key/value pair to the manifest entry iff the value
   /// is non-null. If [jsonValue] is specified, its value will be used instead
   /// of the raw value.
-  _JsonBuilder add(String name, dynamic value, [dynamic jsonValue()]) {
+  JsonBuilder add(String name, dynamic value, [dynamic jsonValue()]) {
     if (value != null) {
       entry[name] = jsonValue == null ? value : jsonValue();
     }
     return this;
   }
+}
+
+/// Throws a [FormatException] if [data] does not contain [key].
+void checkRequiredField(Map<String, dynamic> data, String key) {
+  if (!data.containsKey(key))
+    throw new FormatException('Required field missing: $key');
 }

--- a/lib/src/record_replay/run_manifest_entry.dart
+++ b/lib/src/record_replay/run_manifest_entry.dart
@@ -1,0 +1,148 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io' show ProcessStartMode, SYSTEM_ENCODING;
+
+import 'manifest_entry.dart';
+
+/// Gets a `ProcessStartMode` value by its string name.
+ProcessStartMode _getProcessStartMode(String value) {
+  if (value != null) {
+    for (ProcessStartMode mode in ProcessStartMode.values) {
+      if (mode.toString() == value) {
+        return mode;
+      }
+    }
+    throw new FormatException('Invalid value for mode: $value');
+  }
+  return null;
+}
+
+/// Gets an `Encoding` instance by the encoding name.
+Encoding _getEncoding(String encoding) {
+  if (encoding == 'system') {
+    return SYSTEM_ENCODING;
+  } else if (encoding != null) {
+    return Encoding.getByName(encoding);
+  }
+  return null;
+}
+
+/// An entry in the process invocation manifest for running an executable.
+class RunManifestEntry extends ManifestEntry {
+  @override
+  final String type = 'run';
+
+  /// The process id.
+  final int pid;
+
+  /// The base file name for this entry. `stdout` and `stderr` files for this
+  /// process will be serialized in the recording directory as
+  /// `$basename.stdout` and `$basename.stderr`, respectively.
+  final String basename;
+
+  /// The command that was run. The first element is the executable, and the
+  /// remaining elements are the arguments to the executable.
+  final List<String> command;
+
+  /// The process' working directory when it was spawned.
+  final String workingDirectory;
+
+  /// The environment variables that were passed to the process.
+  final Map<String, String> environment;
+
+  /// Whether the invoker's environment was made available to the process.
+  final bool includeParentEnvironment;
+
+  /// Whether the process was spawned through a system shell.
+  final bool runInShell;
+
+  /// The mode with which the process was spawned.
+  final ProcessStartMode mode;
+
+  /// The encoding used for the `stdout` of the process.
+  final Encoding stdoutEncoding;
+
+  /// The encoding used for the `stderr` of the process.
+  final Encoding stderrEncoding;
+
+  /// The exit code of the process.
+  int exitCode;
+
+  /// Creates a new manifest entry with the given properties.
+  RunManifestEntry({
+    this.pid,
+    this.basename,
+    this.command,
+    this.workingDirectory,
+    this.environment,
+    this.includeParentEnvironment,
+    this.runInShell,
+    this.mode,
+    this.stdoutEncoding,
+    this.stderrEncoding,
+    this.exitCode,
+  });
+
+  /// Creates a new manifest entry populated with the specified JSON [data].
+  ///
+  /// If any required fields are missing from the JSON data, this will throw
+  /// a [FormatException].
+  factory RunManifestEntry.fromJson(Map<String, dynamic> data) {
+    checkRequiredField(data, 'pid');
+    checkRequiredField(data, 'basename');
+    checkRequiredField(data, 'command');
+    RunManifestEntry entry = new RunManifestEntry(
+      pid: data['pid'],
+      basename: data['basename'],
+      command: data['command'],
+      workingDirectory: data['workingDirectory'],
+      environment: data['environment'],
+      includeParentEnvironment: data['includeParentEnvironment'],
+      runInShell: data['runInShell'],
+      mode: _getProcessStartMode(data['mode']),
+      stdoutEncoding: _getEncoding(data['stdoutEncoding']),
+      stderrEncoding: _getEncoding(data['stderrEncoding']),
+      exitCode: data['exitCode'],
+    );
+    entry.daemon = data['daemon'];
+    entry.notResponding = data['notResponding'];
+    return entry;
+  }
+
+  /// The executable that was invoked.
+  String get executable => command.first;
+
+  /// The arguments that were passed to [executable].
+  List<String> get arguments => command.skip(1).toList();
+
+  /// Indicates that the process is a daemon.
+  bool get daemon => _daemon;
+  bool _daemon = false;
+  set daemon(bool value) => _daemon = value ?? false;
+
+  /// Indicates that the process did not respond to `SIGTERM`.
+  bool get notResponding => _notResponding;
+  bool _notResponding = false;
+  set notResponding(bool value) => _notResponding = value ?? false;
+
+  /// Returns a JSON-encodable representation of this manifest entry.
+  @override
+  Map<String, dynamic> toJson() => new JsonBuilder()
+      .add('pid', pid)
+      .add('basename', basename)
+      .add('command', command)
+      .add('workingDirectory', workingDirectory)
+      .add('environment', environment)
+      .add('includeParentEnvironment', includeParentEnvironment)
+      .add('runInShell', runInShell)
+      .add('mode', mode, () => mode.toString())
+      .add('stdoutEncoding', stdoutEncoding, () => stdoutEncoding.name)
+      .add('stderrEncoding', stderrEncoding, () => stderrEncoding.name)
+      .add('daemon', daemon)
+      .add('notResponding', notResponding)
+      .add('exitCode', exitCode)
+      .entry;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,16 @@
 name: process
-version: 1.0.1
+version: 1.1.0
 authors:
 - Todd Volkert <tvolkert@google.com>
 description: A pluggable, mockable process invocation abstraction for Dart.
-homepage: https://github.com/tvolkert/process
+homepage: https://github.com/google/process.dart
 
 dependencies:
   file: ^1.0.1
   intl: '>=0.14.0 <0.15.0'
   meta: ^1.0.4
   path: ^1.4.0
+  platform: ^1.0.1
 
 dev_dependencies:
   test: ^0.12.10

--- a/test/data/replay/MANIFEST.txt
+++ b/test/data/replay/MANIFEST.txt
@@ -1,23 +1,36 @@
 [
   {
-    "pid": 100,
-    "basename": "001.sing.100",
-    "command": [
-      "sing",
-      "ppap"
-    ],
-    "mode": "ProcessStartMode.NORMAL",
-    "exitCode": 0
+    "type": "run",
+    "body": {
+      "pid": 100,
+      "basename": "001.sing.100",
+      "command": [
+        "sing",
+        "ppap"
+      ],
+      "mode": "ProcessStartMode.NORMAL",
+      "exitCode": 0
+    }
   },
   {
-    "pid": 101,
-    "basename": "002.dance.101",
-    "command": [
-      "dance",
-      "gangnam-style"
-    ],
-    "stdoutEncoding": "system",
-    "stderrEncoding": "system",
-    "exitCode": 2
+    "type": "run",
+    "body": {
+      "pid": 101,
+      "basename": "002.dance.101",
+      "command": [
+        "dance",
+        "gangnam-style"
+      ],
+      "stdoutEncoding": "system",
+      "stderrEncoding": "system",
+      "exitCode": 2
+    }
+  },
+  {
+    "type": "can_run",
+    "body": {
+      "executable": "marathon",
+      "result": true
+    }
   }
 ]

--- a/test/replay_test.dart
+++ b/test/replay_test.dart
@@ -51,5 +51,10 @@ void main() {
       expect(result.stdout, '');
       expect(result.stderr, 'No one can dance like Psy\n');
     });
+
+    test('canRun', () {
+      bool result = manager.canRun('marathon');
+      expect(result, true);
+    });
   });
 }

--- a/test/src/interface/common_test.dart
+++ b/test/src/interface/common_test.dart
@@ -1,0 +1,191 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
+import 'package:process/src/interface/common.dart';
+import 'package:test/test.dart';
+
+void main() {
+  FileSystem fs = new LocalFileSystem();
+
+  group('getExecutablePath', () {
+    Directory workingDir, dir1, dir2, dir3;
+
+    setUp(() {
+      workingDir = fs.systemTempDirectory.createTempSync('work_dir_');
+      dir1 = fs.systemTempDirectory.createTempSync('dir1_');
+      dir2 = fs.systemTempDirectory.createTempSync('dir2_');
+      dir3 = fs.systemTempDirectory.createTempSync('dir3_');
+    });
+
+    tearDown(() {
+      <Directory>[workingDir, dir1, dir2, dir3]
+          .forEach((Directory d) => d.deleteSync(recursive: true));
+    });
+
+    group('on windows', () {
+      Platform platform;
+
+      setUp(() {
+        platform = new FakePlatform(
+            operatingSystem: 'windows',
+            environment: <String, String>{
+              'PATH': '${dir1.path};${dir2.path}',
+              'PATHEXT': '.exe;.bat'
+            });
+      });
+
+      test('absolute', () {
+        String command = p.join(dir3.path, 'bla.exe');
+        String expectedPath = command;
+        fs.file(command).createSync();
+
+        String executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+
+        command = p.withoutExtension(command);
+        executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('in path', () {
+        String command = 'bla.exe';
+        String expectedPath = p.join(dir2.path, command);
+        fs.file(expectedPath).createSync();
+
+        String executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+
+        command = p.withoutExtension(command);
+        executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('in path multiple times', () {
+        String command = 'bla.exe';
+        String expectedPath = p.join(dir1.path, command);
+        String wrongPath = p.join(dir2.path, command);
+        fs.file(expectedPath).createSync();
+        fs.file(wrongPath).createSync();
+
+        String executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+
+        command = p.withoutExtension(command);
+        executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('in subdir of work dir', () {
+        String command = p.join('.', 'foo', 'bla.exe');
+        String expectedPath = p.join(workingDir.path, command);
+        fs.file(expectedPath).createSync(recursive: true);
+
+        String executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+
+        command = p.withoutExtension(command);
+        executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('in work dir', () {
+        String command = p.join('.', 'bla.exe');
+        String expectedPath = p.join(workingDir.path, command);
+        String wrongPath = p.join(dir2.path, command);
+        fs.file(expectedPath).createSync();
+        fs.file(wrongPath).createSync();
+
+        String executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+
+        command = p.withoutExtension(command);
+        executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('with multiple extensions', () {
+        String command = 'foo';
+        String expectedPath = p.join(dir1.path, '$command.exe');
+        String wrongPath1 = p.join(dir1.path, '$command.bat');
+        String wrongPath2 = p.join(dir2.path, '$command.exe');
+        fs.file(expectedPath).createSync();
+        fs.file(wrongPath1).createSync();
+        fs.file(wrongPath2).createSync();
+
+        String executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('not found', () {
+        String command = 'foo.exe';
+
+        String executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        expect(executablePath, isNull);
+      });
+    });
+
+    group('on Linux', () {
+      Platform platform;
+
+      setUp(() {
+        platform = new FakePlatform(
+            operatingSystem: 'linux',
+            environment: <String, String>{'PATH': '${dir1.path}:${dir2.path}'});
+      });
+
+      test('absolute', () {
+        String command = p.join(dir3.path, 'bla');
+        String expectedPath = command;
+        String wrongPath = p.join(dir3.path, 'bla.bat');
+        fs.file(command).createSync();
+        fs.file(wrongPath).createSync();
+
+        String executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('in path multiple times', () {
+        String command = 'xxx';
+        String expectedPath = p.join(dir1.path, command);
+        String wrongPath = p.join(dir2.path, command);
+        fs.file(expectedPath).createSync();
+        fs.file(wrongPath).createSync();
+
+        String executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('not found', () {
+        String command = 'foo';
+
+        String executablePath =
+            getExecutablePath(command, workingDir.path, platform: platform);
+        expect(executablePath, isNull);
+      });
+    });
+  });
+}
+
+void _expectSamePath(String actual, String expected) {
+  expect(actual, isNotNull);
+  expect(actual.toLowerCase(), expected.toLowerCase());
+}


### PR DESCRIPTION
`LocalProcessManager` now uses the same algorithm on Windows and Posix systems to find the executable for a command.

Previously, `manager.run(['pub'])` would work on Linux, but not on Windows because `pub.bat` could not be located.