### PR TITLE
Updated package:file dependency to version 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 2.0.0
+
+* Bumped `package:file` dependency to 2.0.1
+
 #### 1.1.0
 
 * Added support to transparently find the right executable under Windows.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process
-version: 1.1.0
+version: 2.0.0
 authors:
 - Todd Volkert <tvolkert@google.com>
 - Michael Goderbauer <goderbauer@google.com>
@@ -7,7 +7,7 @@ description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 
 dependencies:
-  file: ^1.0.1
+  file: ^2.0.1
   intl: '>=0.14.0 <0.15.0'
   meta: ^1.0.4
   path: ^1.4.0


### PR DESCRIPTION
This requires bumping our version to 2.0.0 since we expose
FileSystem references in our API, and the Filesystem API
version changed in version 2.0.0