### PR TITLE
Remove `set exitCode`

### DIFF
--- a/lib/src/record_replay/recording_process_manager.dart
+++ b/lib/src/record_replay/recording_process_manager.dart
@@ -388,11 +388,6 @@ class _RecordingProcess implements io.Process {
   @override
   Future<int> get exitCode => delegate.exitCode;
 
-  // TODO(tvolkert): Remove this once dart-lang/sdk@e5a16b1 lands in stable SDK.
-  @override // ignore: OVERRIDE_ON_NON_OVERRIDING_SETTER
-  set exitCode(Future<int> exitCode) =>
-      throw new UnsupportedError('set exitCode');
-
   @override
   Stream<List<int>> get stdout {
     assert(_started);

--- a/lib/src/record_replay/replay_process_manager.dart
+++ b/lib/src/record_replay/replay_process_manager.dart
@@ -307,11 +307,6 @@ class _ReplayProcess implements io.Process {
   @override
   Future<int> get exitCode => _exitCodeCompleter.future;
 
-  // TODO(tvolkert): Remove this once dart-lang/sdk@e5a16b1 lands in stable SDK.
-  @override // ignore: OVERRIDE_ON_NON_OVERRIDING_SETTER
-  set exitCode(Future<int> exitCode) =>
-      throw new UnsupportedError('set exitCode');
-
   @override
   io.IOSink get stdin => throw new UnimplementedError();
 


### PR DESCRIPTION
It's no longer defined in the SDK, which means we no longer
have to (and no longer should) override it.