### PR TITLE
Fix a uses_dynamic_as_bottom error in record_replay/manifest.dart

### DIFF
--- a/lib/src/record_replay/manifest.dart
+++ b/lib/src/record_replay/manifest.dart
@@ -20,10 +20,10 @@ bool _areListsEqual<T>(List<T> list1, List<T> list2) {
 
 /// Tells whether [testValue] is non-null and equal to [entryValue]. If
 /// [isEqual] is specified, it will be used to determine said equality.
-bool _isHit(
-  dynamic entryValue,
-  dynamic testValue, [
-  bool isEqual(dynamic value1, dynamic value2),
+bool _isHit<T>(
+  T entryValue,
+  T testValue, [
+  bool isEqual(T value1, T value2),
 ]) {
   if (testValue == null) {
     return true;


### PR DESCRIPTION
With this fix, `_areListsEqual` can be passed in as the 3rd argument to `_isHit`, and reliably expect Lists.