### PR TITLE
Remove @visibleForTesting from getExecutablePath

### DIFF
--- a/lib/src/interface/common.dart
+++ b/lib/src/interface/common.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io' show File, Directory;
 
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 
@@ -12,7 +11,6 @@ import 'package:platform/platform.dart';
 /// to launch.
 ///
 /// Return `null` if the executable cannot be found.
-@visibleForTesting
 String getExecutablePath(String commandName, String workingDirectory,
     {Platform platform}) {
   platform ??= new LocalPlatform();


### PR DESCRIPTION
`getExecutablePath` is used in `lib/src/interface/local_process_manager.dart`, which is not a test.