### PR TITLE
Rename Process to ProcessWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+#### 3.0.7
+
+* Renamed `Process` to `ProcessWrapper`
+
 #### 3.0.6
 
 * Added class `Process`, a simple wrapper around dart:io's `Process` class.

--- a/lib/process.dart
+++ b/lib/process.dart
@@ -3,5 +3,5 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'src/interface/local_process_manager.dart';
-export 'src/interface/process.dart';
 export 'src/interface/process_manager.dart';
+export 'src/interface/process_wrapper.dart';

--- a/lib/src/interface/process_wrapper.dart
+++ b/lib/src/interface/process_wrapper.dart
@@ -5,10 +5,10 @@
 import 'dart:io' as io;
 
 /// A wrapper around an [io.Process] class that adds some convenience methods.
-class Process implements io.Process {
-  /// Constructs a [Process] object that delegates to the specified underlying
-  /// object.
-  const Process(this.delegate);
+class ProcessWrapper implements io.Process {
+  /// Constructs a [ProcessWrapper] object that delegates to the specified
+  /// underlying object.
+  const ProcessWrapper(this.delegate);
 
   final io.Process delegate;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process
-version: 3.0.6
+version: 3.0.7
 authors:
 - Todd Volkert <tvolkert@google.com>
 - Michael Goderbauer <goderbauer@google.com>

--- a/test/src/interface/process_wrapper_test.dart
+++ b/test/src/interface/process_wrapper_test.dart
@@ -12,7 +12,7 @@ void main() {
   group('done', () {
     test('completes only when all done', () async {
       TestProcess delegate = new TestProcess();
-      Process process = new Process(delegate);
+      ProcessWrapper process = new ProcessWrapper(delegate);
       bool done = false;
       // ignore: unawaited_futures
       process.done.then((int result) {


### PR DESCRIPTION
As `Process`, it was causing namespace collisions with dart:io's `Process`