### PR TITLE
Fix bug in `ProcessWrapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+#### 3.0.8
+
+* Fixed bug in `ProcessWrapper`
+
 #### 3.0.7
 
 * Renamed `Process` to `ProcessWrapper`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process
-version: 3.0.7
+version: 3.0.8
 authors:
 - Todd Volkert <tvolkert@google.com>
 - Michael Goderbauer <goderbauer@google.com>


### PR DESCRIPTION
The `done` getter listened to the stdio streams, which opened up
the possibility of multiple listeners on a single-subscription
stream.