### PR TITLE
Update intl version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 3.0.12
+
+* Updated version constraint on intl.
+
 #### 3.0.11
 
 * Fix bug: don't add quotes if the file name already has quotes.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ homepage: https://github.com/google/process.dart
 
 dependencies:
   file: '^5.0.0'
-  intl: '>=0.14.0 <0.16.0'
+  intl: '>=0.14.0 <0.17.0'
   meta: ^1.1.2
   path: ^1.5.1
   platform: '>=1.0.1'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process
-version: 3.0.11
+version: 3.0.12
 authors:
 - Todd Volkert <tvolkert@google.com>
 - Michael Goderbauer <goderbauer@google.com>


### PR DESCRIPTION
Flutter needs this constraint updated so we can roll new versions of intl and devtools