### PR TITLE
Handle throwing fs.currentDirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 3.0.13
+
+* Handle `currentDirectory` throwing an exception in `getExecutablePath()`.
+
 #### 3.0.12
 
 * Updated version constraint on intl.

--- a/lib/src/interface/common.dart
+++ b/lib/src/interface/common.dart
@@ -56,7 +56,14 @@ String getExecutablePath(
 }) {
   assert(_osToPathStyle[platform.operatingSystem] == fs.path.style.name);
 
-  workingDirectory ??= fs.currentDirectory.path;
+  try {
+    workingDirectory ??= fs.currentDirectory.path;
+  } on FileSystemException {
+    // The `currentDirectory` getter can throw a FileSystemException for example
+    // when the process doesn't have read/list permissions in each component of
+    // the cwd path. In this case, fall back on '.'.
+    workingDirectory ??= '.';
+  }
   Context context =
       new Context(style: fs.path.style, current: workingDirectory);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process
-version: 3.0.12
+version: 3.0.13
 authors:
 - Todd Volkert <tvolkert@google.com>
 - Michael Goderbauer <goderbauer@google.com>

--- a/test/src/interface/common_test.dart
+++ b/test/src/interface/common_test.dart
@@ -213,6 +213,34 @@ void main() {
                 platform: platform),
             'C:\\\"Program Files\"\\bla.exe');
       });
+
+      test('with absolute path when currentDirectory getter throws', () {
+        FileSystem fsNoCwd = MemoryFileSystemNoCwd(fs);
+        String command = fs.path.join(dir3.path, 'bla.exe');
+        String expectedPath = command;
+        fs.file(command).createSync();
+
+        String executablePath = getExecutablePath(
+          command,
+          null,
+          platform: platform,
+          fs: fsNoCwd,
+        );
+        _expectSamePath(executablePath, expectedPath);
+      });
+
+      test('with relative path when currentDirectory getter throws', () {
+        FileSystem fsNoCwd = MemoryFileSystemNoCwd(fs);
+        String command = fs.path.join('.', 'bla.exe');
+
+        String executablePath = getExecutablePath(
+          command,
+          null,
+          platform: platform,
+          fs: fsNoCwd,
+        );
+        expect(executablePath, isNull);
+      });
     });
 
     group('on Linux', () {
@@ -283,4 +311,13 @@ void main() {
 void _expectSamePath(String actual, String expected) {
   expect(actual, isNotNull);
   expect(actual.toLowerCase(), expected.toLowerCase());
+}
+
+class MemoryFileSystemNoCwd extends ForwardingFileSystem {
+  MemoryFileSystemNoCwd(FileSystem delegate) : super(delegate);
+
+  @override
+  Directory get currentDirectory {
+    throw FileSystemException('Access denied');
+  }
 }


### PR DESCRIPTION
Trying to grab the current directory can throw a `FileSystemException`. For example if the process doesn't have read/list permission in each component of the cwd, `getcwd()` on Linux fails with `EACCES`. This PR uses '.' as the cwd to search for the command paths in this case. (Hopefully the command is an absolute path, but if not '.' might work.)

https://github.com/flutter/flutter/issues/57166

Fixes https://github.com/google/process.dart/issues/43