### PR TITLE
Fix pub warnings for publication

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,5 @@
 name: process
 version: 3.0.13
-authors:
-- Todd Volkert <tvolkert@google.com>
-- Michael Goderbauer <goderbauer@google.com>
 description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 
@@ -17,4 +14,4 @@ dev_dependencies:
   test: ^1.0.0
 
 environment:
-  sdk: '>=2.0.0-dev.61 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
Publication is blocked on:
```
Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version.
```

It also warns about:
```
Your pubspec.yaml includes an "authors" section which is no longer used and may be removed.
```