### PR TITLE
[null-safety] remove implicit casts, intl dependency, format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 4.0.0-dev
+
+* Remove implicit casts in preparation for null-safety
+* Remove dependency on `package:intl`
+
 #### 3.0.13
 
 * Handle `currentDirectory` throwing an exception in `getExecutablePath()`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,8 +1,7 @@
 analyzer:
-  language:
-    enableSuperMixins: true
   strong-mode:
     implicit-dynamic: false
+    implicit-casts: false
   errors:
     missing_required_param: warning
     missing_return: warning
@@ -36,13 +35,11 @@ linter:
     - always_declare_return_types
     - always_specify_types
     - annotate_overrides
-    - avoid_as
     - avoid_init_to_null
     - avoid_return_types_on_setters
     - await_only_futures
     - camel_case_types
     - constant_identifier_names
-    - control_flow_in_finally
     - empty_constructor_bodies
     - implementation_imports
     - library_names
@@ -58,7 +55,6 @@ linter:
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
-    - super_goes_last
     - type_annotate_public_apis
     - type_init_formals
     - unawaited_futures

--- a/lib/src/interface/common.dart
+++ b/lib/src/interface/common.dart
@@ -53,7 +53,6 @@ String getExecutablePath(
   String workingDirectory, {
   Platform platform = const LocalPlatform(),
   FileSystem fs = const LocalFileSystem(),
-  bool windows = false,
 }) {
   assert(_osToPathStyle[platform.operatingSystem] == fs.path.style.name);
 

--- a/lib/src/interface/common.dart
+++ b/lib/src/interface/common.dart
@@ -7,7 +7,7 @@ import 'package:file/local.dart';
 import 'package:path/path.dart' show Context;
 import 'package:platform/platform.dart';
 
-const Map<String, String> _osToPathStyle = const <String, String>{
+const Map<String, String> _osToPathStyle = <String, String>{
   'linux': 'posix',
   'macos': 'posix',
   'android': 'posix',
@@ -51,8 +51,9 @@ String sanitizeExecutablePath(String executable,
 String getExecutablePath(
   String command,
   String workingDirectory, {
-  Platform platform: const LocalPlatform(),
-  FileSystem fs: const LocalFileSystem(),
+  Platform platform = const LocalPlatform(),
+  FileSystem fs = const LocalFileSystem(),
+  bool windows = false,
 }) {
   assert(_osToPathStyle[platform.operatingSystem] == fs.path.style.name);
 
@@ -64,8 +65,7 @@ String getExecutablePath(
     // the cwd path. In this case, fall back on '.'.
     workingDirectory ??= '.';
   }
-  Context context =
-      new Context(style: fs.path.style, current: workingDirectory);
+  Context context = Context(style: fs.path.style, current: workingDirectory);
 
   // TODO(goderbauer): refactor when github.com/google/platform.dart/issues/2
   //     is available.
@@ -95,7 +95,7 @@ String getExecutablePath(
 /// `$searchPath\$command`.
 /// If [command] is an absolute path, it will just enumerate
 /// `$command.$ext`.
-Iterable<String> _getCandidatePaths(
+List<String> _getCandidatePaths(
   String command,
   List<String> searchPaths,
   List<String> extensions,

--- a/lib/src/interface/local_process_manager.dart
+++ b/lib/src/interface/local_process_manager.dart
@@ -12,8 +12,6 @@ import 'dart:io'
         ProcessStartMode,
         systemEncoding;
 
-import 'package:platform/platform.dart';
-
 import 'common.dart';
 import 'process_manager.dart';
 
@@ -35,9 +33,9 @@ class LocalProcessManager implements ProcessManager {
     covariant List<Object> command, {
     String workingDirectory,
     Map<String, String> environment,
-    bool includeParentEnvironment: true,
-    bool runInShell: false,
-    ProcessStartMode mode: ProcessStartMode.normal,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    ProcessStartMode mode = ProcessStartMode.normal,
   }) {
     return Process.start(
       sanitizeExecutablePath(_getExecutable(
@@ -59,10 +57,10 @@ class LocalProcessManager implements ProcessManager {
     covariant List<Object> command, {
     String workingDirectory,
     Map<String, String> environment,
-    bool includeParentEnvironment: true,
-    bool runInShell: false,
-    Encoding stdoutEncoding: systemEncoding,
-    Encoding stderrEncoding: systemEncoding,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding stdoutEncoding = systemEncoding,
+    Encoding stderrEncoding = systemEncoding,
   }) {
     return Process.run(
       sanitizeExecutablePath(_getExecutable(
@@ -85,10 +83,10 @@ class LocalProcessManager implements ProcessManager {
     covariant List<Object> command, {
     String workingDirectory,
     Map<String, String> environment,
-    bool includeParentEnvironment: true,
-    bool runInShell: false,
-    Encoding stdoutEncoding: systemEncoding,
-    Encoding stderrEncoding: systemEncoding,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding stdoutEncoding = systemEncoding,
+    Encoding stderrEncoding = systemEncoding,
   }) {
     return Process.runSync(
       sanitizeExecutablePath(_getExecutable(
@@ -107,7 +105,7 @@ class LocalProcessManager implements ProcessManager {
   }
 
   @override
-  bool canRun(covariant Object executable, {String workingDirectory}) =>
+  bool canRun(covariant String executable, {String workingDirectory}) =>
       getExecutablePath(executable, workingDirectory) != null;
 
   @override
@@ -124,7 +122,7 @@ String _getExecutable(
   }
   String exe = getExecutablePath(commandName, workingDirectory);
   if (exe == null) {
-    throw new ArgumentError('Cannot find executable for $commandName.');
+    throw ArgumentError('Cannot find executable for $commandName.');
   }
   return exe;
 }

--- a/lib/src/interface/process_manager.dart
+++ b/lib/src/interface/process_manager.dart
@@ -87,9 +87,9 @@ abstract class ProcessManager {
     List<dynamic> command, {
     String workingDirectory,
     Map<String, String> environment,
-    bool includeParentEnvironment: true,
-    bool runInShell: false,
-    ProcessStartMode mode: ProcessStartMode.normal,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    ProcessStartMode mode = ProcessStartMode.normal,
   });
 
   /// Starts a process and runs it non-interactively to completion.
@@ -140,10 +140,10 @@ abstract class ProcessManager {
     List<dynamic> command, {
     String workingDirectory,
     Map<String, String> environment,
-    bool includeParentEnvironment: true,
-    bool runInShell: false,
-    Encoding stdoutEncoding: systemEncoding,
-    Encoding stderrEncoding: systemEncoding,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding stdoutEncoding = systemEncoding,
+    Encoding stderrEncoding = systemEncoding,
   });
 
   /// Starts a process and runs it to completion. This is a synchronous
@@ -157,10 +157,10 @@ abstract class ProcessManager {
     List<dynamic> command, {
     String workingDirectory,
     Map<String, String> environment,
-    bool includeParentEnvironment: true,
-    bool runInShell: false,
-    Encoding stdoutEncoding: systemEncoding,
-    Encoding stderrEncoding: systemEncoding,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding stdoutEncoding = systemEncoding,
+    Encoding stderrEncoding = systemEncoding,
   });
 
   /// Returns `true` if the [executable] exists and if it can be executed.

--- a/lib/src/interface/process_wrapper.dart
+++ b/lib/src/interface/process_wrapper.dart
@@ -10,10 +10,10 @@ class ProcessWrapper implements io.Process {
   /// Constructs a [ProcessWrapper] object that delegates to the specified
   /// underlying object.
   ProcessWrapper(this._delegate)
-      : _stdout = new StreamController<List<int>>(),
-        _stderr = new StreamController<List<int>>(),
-        _stdoutDone = new Completer<void>(),
-        _stderrDone = new Completer<void>() {
+      : _stdout = StreamController<List<int>>(),
+        _stderr = StreamController<List<int>>(),
+        _stdoutDone = Completer<void>(),
+        _stderrDone = Completer<void>() {
     _monitorStdioStream(_delegate.stdout, _stdout, _stdoutDone);
     _monitorStdioStream(_delegate.stderr, _stderr, _stderrDone);
   }

--- a/lib/src/record_replay/can_run_manifest_entry.dart
+++ b/lib/src/record_replay/can_run_manifest_entry.dart
@@ -2,15 +2,6 @@ import 'manifest_entry.dart';
 
 /// An entry in the process invocation manifest for `canRun`.
 class CanRunManifestEntry extends ManifestEntry {
-  @override
-  final String type = 'can_run';
-
-  /// The name of the executable for which the run-ability is checked.
-  final String executable;
-
-  /// The result of the check.
-  final bool result;
-
   /// Creates a new manifest entry with the given properties.
   CanRunManifestEntry({this.executable, this.result});
 
@@ -21,16 +12,23 @@ class CanRunManifestEntry extends ManifestEntry {
   factory CanRunManifestEntry.fromJson(Map<String, dynamic> data) {
     checkRequiredField(data, 'executable');
     checkRequiredField(data, 'result');
-    CanRunManifestEntry entry = new CanRunManifestEntry(
-      executable: data['executable'],
-      result: data['result'],
+    CanRunManifestEntry entry = CanRunManifestEntry(
+      executable: data['executable'] as String,
+      result: data['result'] as bool,
     );
     return entry;
   }
 
   @override
-  Map<String, dynamic> toJson() => new JsonBuilder()
-      .add('executable', executable)
-      .add('result', result)
-      .entry;
+  final String type = 'can_run';
+
+  /// The name of the executable for which the run-ability is checked.
+  final String executable;
+
+  /// The result of the check.
+  final bool result;
+
+  @override
+  Map<String, dynamic> toJson() =>
+      JsonBuilder().add('executable', executable).add('result', result).entry;
 }

--- a/lib/src/record_replay/command_element.dart
+++ b/lib/src/record_replay/command_element.dart
@@ -6,7 +6,7 @@ import 'package:process/process.dart';
 
 /// Callback used to [sanitize](CommandElement.sanitized) a [CommandElement]
 /// for the purpose of recording.
-typedef String CommandSanitizer(String rawValue);
+typedef CommandSanitizer = String Function(String rawValue);
 
 /// A command element capable of holding both a raw and sanitized value.
 ///
@@ -29,8 +29,6 @@ typedef String CommandSanitizer(String rawValue);
 /// instances of this class can be passed directly to [LocalProcessManager]
 /// and will work as intended.
 class CommandElement {
-  final CommandSanitizer _sanitizer;
-
   /// Creates a new command element with the specified [raw] value.
   ///
   /// If a [sanitizer] is specified, it will be used to generate this command
@@ -38,6 +36,8 @@ class CommandElement {
   /// used as the sanitized value.
   CommandElement(this.raw, {CommandSanitizer sanitizer})
       : _sanitizer = sanitizer;
+
+  final CommandSanitizer _sanitizer;
 
   /// This command element's raw, unsanitized, value.
   ///

--- a/lib/src/record_replay/manifest.dart
+++ b/lib/src/record_replay/manifest.dart
@@ -36,8 +36,6 @@ bool _isHit<T>(
 /// The process invocation manifest, holding metadata about every recorded
 /// process invocation.
 class Manifest {
-  final List<ManifestEntry> _entries = <ManifestEntry>[];
-
   /// Creates a new manifest.
   Manifest();
 
@@ -47,24 +45,27 @@ class Manifest {
   /// [toJson]), a [FormatException] will be thrown.
   factory Manifest.fromJson(String json) {
     List<Map<String, dynamic>> decoded =
-        new JsonDecoder().convert(json).cast<Map<String, dynamic>>();
-    Manifest manifest = new Manifest();
+        (JsonDecoder().convert(json) as List<dynamic>)
+            .cast<Map<String, dynamic>>();
+    Manifest manifest = Manifest();
     decoded.forEach((Map<String, dynamic> entry) {
-      switch (entry['type']) {
+      switch (entry['type'] as String) {
         case 'run':
-          manifest._entries.add(new RunManifestEntry.fromJson(entry['body']));
+          manifest._entries.add(
+              RunManifestEntry.fromJson(entry['body'] as Map<String, dynamic>));
           break;
         case 'can_run':
-          manifest._entries
-              .add(new CanRunManifestEntry.fromJson(entry['body']));
+          manifest._entries.add(CanRunManifestEntry.fromJson(
+              entry['body'] as Map<String, dynamic>));
           break;
         default:
-          throw new UnsupportedError(
-              'Manifest type ${entry['type']} is unkown.');
+          throw UnsupportedError('Manifest type ${entry['type']} is unkown.');
       }
     });
     return manifest;
   }
+
+  final List<ManifestEntry> _entries = <ManifestEntry>[];
 
   /// Adds the specified [entry] to this manifest.
   void add(ManifestEntry entry) => _entries.add(entry);
@@ -119,7 +120,7 @@ class Manifest {
   /// Returns a JSON-encoded representation of this manifest.
   String toJson() {
     List<Map<String, dynamic>> list = <Map<String, dynamic>>[];
-    _entries.forEach((ManifestEntry entry) => list.add(new JsonBuilder()
+    _entries.forEach((ManifestEntry entry) => list.add(JsonBuilder()
         .add('type', entry.type)
         .add('body', entry.toJson())
         .entry));

--- a/lib/src/record_replay/manifest.dart
+++ b/lib/src/record_replay/manifest.dart
@@ -45,8 +45,7 @@ class Manifest {
   /// [toJson]), a [FormatException] will be thrown.
   factory Manifest.fromJson(String json) {
     List<Map<String, dynamic>> decoded =
-        (jsonDecode(json) as List<dynamic>)
-            .cast<Map<String, dynamic>>();
+        (jsonDecode(json) as List<dynamic>).cast<Map<String, dynamic>>();
     Manifest manifest = Manifest();
     decoded.forEach((Map<String, dynamic> entry) {
       switch (entry['type'] as String) {

--- a/lib/src/record_replay/manifest.dart
+++ b/lib/src/record_replay/manifest.dart
@@ -45,7 +45,7 @@ class Manifest {
   /// [toJson]), a [FormatException] will be thrown.
   factory Manifest.fromJson(String json) {
     List<Map<String, dynamic>> decoded =
-        (JsonDecoder().convert(json) as List<dynamic>)
+        (jsonDecode(json) as List<dynamic>)
             .cast<Map<String, dynamic>>();
     Manifest manifest = Manifest();
     decoded.forEach((Map<String, dynamic> entry) {

--- a/lib/src/record_replay/manifest_entry.dart
+++ b/lib/src/record_replay/manifest_entry.dart
@@ -42,5 +42,5 @@ class JsonBuilder {
 /// Throws a [FormatException] if [data] does not contain [key].
 void checkRequiredField(Map<String, dynamic> data, String key) {
   if (!data.containsKey(key))
-    throw new FormatException('Required field missing: $key');
+    throw FormatException('Required field missing: $key');
 }

--- a/lib/src/record_replay/run_manifest_entry.dart
+++ b/lib/src/record_replay/run_manifest_entry.dart
@@ -15,7 +15,7 @@ ProcessStartMode _getProcessStartMode(String value) {
         return mode;
       }
     }
-    throw new FormatException('Invalid value for mode: $value');
+    throw FormatException('Invalid value for mode: $value');
   }
   return null;
 }
@@ -32,6 +32,48 @@ Encoding _getEncoding(String encoding) {
 
 /// An entry in the process invocation manifest for running an executable.
 class RunManifestEntry extends ManifestEntry {
+  /// Creates a new manifest entry with the given properties.
+  RunManifestEntry({
+    this.pid,
+    this.basename,
+    this.command,
+    this.workingDirectory,
+    this.environment,
+    this.includeParentEnvironment,
+    this.runInShell,
+    this.mode,
+    this.stdoutEncoding,
+    this.stderrEncoding,
+    this.exitCode,
+  });
+
+  /// Creates a new manifest entry populated with the specified JSON [data].
+  ///
+  /// If any required fields are missing from the JSON data, this will throw
+  /// a [FormatException].
+  factory RunManifestEntry.fromJson(Map<String, dynamic> data) {
+    checkRequiredField(data, 'pid');
+    checkRequiredField(data, 'basename');
+    checkRequiredField(data, 'command');
+    RunManifestEntry entry = RunManifestEntry(
+      pid: data['pid'] as int,
+      basename: data['basename'] as String,
+      command: (data['command'] as List<dynamic>)?.cast<String>(),
+      workingDirectory: data['workingDirectory'] as String,
+      environment: (data['environment'] as Map<dynamic, dynamic>)
+          ?.cast<String, String>(),
+      includeParentEnvironment: data['includeParentEnvironment'] as bool,
+      runInShell: data['runInShell'] as bool,
+      mode: _getProcessStartMode(data['mode'] as String),
+      stdoutEncoding: _getEncoding(data['stdoutEncoding'] as String),
+      stderrEncoding: _getEncoding(data['stderrEncoding'] as String),
+      exitCode: data['exitCode'] as int,
+    );
+    entry.daemon = data['daemon'] as bool;
+    entry.notResponding = data['notResponding'] as bool;
+    return entry;
+  }
+
   @override
   final String type = 'run';
 
@@ -71,47 +113,6 @@ class RunManifestEntry extends ManifestEntry {
   /// The exit code of the process.
   int exitCode;
 
-  /// Creates a new manifest entry with the given properties.
-  RunManifestEntry({
-    this.pid,
-    this.basename,
-    this.command,
-    this.workingDirectory,
-    this.environment,
-    this.includeParentEnvironment,
-    this.runInShell,
-    this.mode,
-    this.stdoutEncoding,
-    this.stderrEncoding,
-    this.exitCode,
-  });
-
-  /// Creates a new manifest entry populated with the specified JSON [data].
-  ///
-  /// If any required fields are missing from the JSON data, this will throw
-  /// a [FormatException].
-  factory RunManifestEntry.fromJson(Map<String, dynamic> data) {
-    checkRequiredField(data, 'pid');
-    checkRequiredField(data, 'basename');
-    checkRequiredField(data, 'command');
-    RunManifestEntry entry = new RunManifestEntry(
-      pid: data['pid'],
-      basename: data['basename'],
-      command: data['command']?.cast<String>(),
-      workingDirectory: data['workingDirectory'],
-      environment: data['environment'],
-      includeParentEnvironment: data['includeParentEnvironment'],
-      runInShell: data['runInShell'],
-      mode: _getProcessStartMode(data['mode']),
-      stdoutEncoding: _getEncoding(data['stdoutEncoding']),
-      stderrEncoding: _getEncoding(data['stderrEncoding']),
-      exitCode: data['exitCode'],
-    );
-    entry.daemon = data['daemon'];
-    entry.notResponding = data['notResponding'];
-    return entry;
-  }
-
   /// The executable that was invoked.
   String get executable => command.first;
 
@@ -130,7 +131,7 @@ class RunManifestEntry extends ManifestEntry {
 
   /// Returns a JSON-encodable representation of this manifest entry.
   @override
-  Map<String, dynamic> toJson() => new JsonBuilder()
+  Map<String, dynamic> toJson() => JsonBuilder()
       .add('pid', pid)
       .add('basename', basename)
       .add('command', command)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,6 @@ homepage: https://github.com/google/process.dart
 
 dependencies:
   file: '^5.0.0'
-  intl: '>=0.14.0 <0.17.0'
   meta: ^1.1.2
   path: ^1.5.1
   platform: '>=1.0.1'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process
-version: 3.0.13
+version: 4.0.0-dev
 description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 

--- a/test/record_test.dart
+++ b/test/record_test.dart
@@ -15,7 +15,7 @@ import 'package:test/test.dart';
 import 'utils.dart';
 
 void main() {
-  FileSystem fs = new LocalFileSystem();
+  FileSystem fs = LocalFileSystem();
   // TODO(goderbauer): refactor when github.com/google/platform.dart/issues/1
   //     is available.
   String newline = Platform.isWindows ? '\r\n' : '\n';
@@ -26,7 +26,7 @@ void main() {
 
     setUp(() {
       tmp = fs.systemTempDirectory.createTempSync('process_tests_');
-      manager = new RecordingProcessManager(new LocalProcessManager(), tmp);
+      manager = RecordingProcessManager(LocalProcessManager(), tmp);
     });
 
     tearDown(() {
@@ -47,11 +47,11 @@ void main() {
       // Force the recording to be written to disk.
       await manager.flush(finishRunningProcesses: true);
 
-      _Recording recording = new _Recording(tmp);
+      _Recording recording = _Recording(tmp);
       expect(recording.manifest, hasLength(1));
       Map<String, dynamic> entry = recording.manifest.first;
       expect(entry['type'], 'run');
-      Map<String, dynamic> body = entry['body'];
+      Map<String, dynamic> body = entry['body'] as Map<String, dynamic>;
       expect(body['pid'], pid);
       expect(body['command'], <String>['echo', 'foo']);
       expect(body['mode'], 'normal');
@@ -65,8 +65,8 @@ void main() {
           await manager.run(<String>['echo', 'bar'], runInShell: true);
       int pid = result.pid;
       int exitCode = result.exitCode;
-      String stdout = result.stdout;
-      String stderr = result.stderr;
+      String stdout = result.stdout as String;
+      String stderr = result.stderr as String;
       expect(exitCode, 0);
       expect(stdout, 'bar$newline');
       expect(stderr, isEmpty);
@@ -74,11 +74,11 @@ void main() {
       // Force the recording to be written to disk.
       await manager.flush(finishRunningProcesses: true);
 
-      _Recording recording = new _Recording(tmp);
+      _Recording recording = _Recording(tmp);
       expect(recording.manifest, hasLength(1));
       Map<String, dynamic> entry = recording.manifest.first;
       expect(entry['type'], 'run');
-      Map<String, dynamic> body = entry['body'];
+      Map<String, dynamic> body = entry['body'] as Map<String, dynamic>;
       expect(body['pid'], pid);
       expect(body['command'], <String>['echo', 'bar']);
       expect(body['stdoutEncoding'], 'system');
@@ -93,8 +93,8 @@ void main() {
           manager.runSync(<String>['echo', 'baz'], runInShell: true);
       int pid = result.pid;
       int exitCode = result.exitCode;
-      String stdout = result.stdout;
-      String stderr = result.stderr;
+      String stdout = result.stdout as String;
+      String stderr = result.stderr as String;
       expect(exitCode, 0);
       expect(stdout, 'baz$newline');
       expect(stderr, isEmpty);
@@ -102,11 +102,11 @@ void main() {
       // Force the recording to be written to disk.
       await manager.flush(finishRunningProcesses: true);
 
-      _Recording recording = new _Recording(tmp);
+      _Recording recording = _Recording(tmp);
       expect(recording.manifest, hasLength(1));
       Map<String, dynamic> entry = recording.manifest.first;
       expect(entry['type'], 'run');
-      Map<String, dynamic> body = entry['body'];
+      Map<String, dynamic> body = entry['body'] as Map<String, dynamic>;
       expect(body['pid'], pid);
       expect(body['command'], <String>['echo', 'baz']);
       expect(body['stdoutEncoding'], 'system');
@@ -125,11 +125,11 @@ void main() {
       // Force the recording to be written to disk.
       await manager.flush(finishRunningProcesses: true);
 
-      _Recording recording = new _Recording(tmp);
+      _Recording recording = _Recording(tmp);
       expect(recording.manifest, hasLength(1));
       Map<String, dynamic> entry = recording.manifest.first;
       expect(entry['type'], 'can_run');
-      Map<String, dynamic> body = entry['body'];
+      Map<String, dynamic> body = entry['body'] as Map<String, dynamic>;
       expect(body['executable'], executable);
       expect(body['result'], result);
     });
@@ -138,21 +138,21 @@ void main() {
 
 /// A testing utility class that encapsulates a recording.
 class _Recording {
+  _Recording(this.dir);
   final Directory dir;
 
-  _Recording(this.dir);
-
   List<Map<String, dynamic>> get manifest {
-    return json.decoder
-        .convert(_getFileContent('MANIFEST.txt', utf8))
+    return (json.decoder
+                .convert(_getFileContent('MANIFEST.txt', utf8) as String)
+            as List<dynamic>)
         .cast<Map<String, dynamic>>();
   }
 
-  dynamic stdoutForEntryAt(int index) =>
-      _getStdioContent(manifest[index]['body'], 'stdout');
+  dynamic stdoutForEntryAt(int index) => _getStdioContent(
+      manifest[index]['body'] as Map<String, dynamic>, 'stdout');
 
-  dynamic stderrForEntryAt(int index) =>
-      _getStdioContent(manifest[index]['body'], 'stderr');
+  dynamic stderrForEntryAt(int index) => _getStdioContent(
+      manifest[index]['body'] as Map<String, dynamic>, 'stderr');
 
   dynamic _getFileContent(String name, Encoding encoding) {
     File file = dir.fileSystem.file('${dir.path}/$name');
@@ -162,8 +162,8 @@ class _Recording {
   }
 
   dynamic _getStdioContent(Map<String, dynamic> entry, String type) {
-    String basename = entry['basename'];
-    String encodingName = entry['${type}Encoding'];
+    String basename = entry['basename'] as String;
+    String encodingName = entry['${type}Encoding'] as String;
     Encoding encoding;
     if (encodingName != null)
       encoding = encodingName == 'system'

--- a/test/replay_test.dart
+++ b/test/replay_test.dart
@@ -13,7 +13,7 @@ import 'package:test/test.dart';
 import 'utils.dart';
 
 void main() {
-  FileSystem fs = new LocalFileSystem();
+  FileSystem fs = LocalFileSystem();
 
   group('ReplayProcessManager', () {
     ProcessManager manager;

--- a/test/src/interface/common_test.dart
+++ b/test/src/interface/common_test.dart
@@ -15,7 +15,7 @@ void main() {
 
     void initialize(FileSystemStyle style) {
       setUp(() {
-        fs = new MemoryFileSystem(style: style);
+        fs = MemoryFileSystem(style: style);
         workingDir = fs.systemTempDirectory.createTempSync('work_dir_');
         dir1 = fs.systemTempDirectory.createTempSync('dir1_');
         dir2 = fs.systemTempDirectory.createTempSync('dir2_');
@@ -34,7 +34,7 @@ void main() {
       initialize(FileSystemStyle.windows);
 
       setUp(() {
-        platform = new FakePlatform(
+        platform = FakePlatform(
           operatingSystem: 'windows',
           environment: <String, String>{
             'PATH': '${dir1.path};${dir2.path}',
@@ -249,7 +249,7 @@ void main() {
       initialize(FileSystemStyle.posix);
 
       setUp(() {
-        platform = new FakePlatform(
+        platform = FakePlatform(
             operatingSystem: 'linux',
             environment: <String, String>{'PATH': '${dir1.path}:${dir2.path}'});
       });


### PR DESCRIPTION
Preparation for null-safety which does not have implicit casts. Removes intl dependency which was only used for a single naming scheme.

Does not bump versioning or changelog