### PR TITLE
Fix ProcessManager signatures to be consistent with LocalProcessManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 4.0.1
+
+* Fix the signatures of `ProcessManager.run`, `.runSync`, and `.start` to be
+  consistent with `LocalProcessManager`'s.
+
 #### 4.0.0
 
 * First stable null safe release.

--- a/lib/src/interface/local_process_manager.dart
+++ b/lib/src/interface/local_process_manager.dart
@@ -29,7 +29,7 @@ class LocalProcessManager implements ProcessManager {
 
   @override
   Future<Process> start(
-    covariant List<Object> command, {
+    List<Object> command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
@@ -53,7 +53,7 @@ class LocalProcessManager implements ProcessManager {
 
   @override
   Future<ProcessResult> run(
-    covariant List<Object> command, {
+    List<Object> command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
@@ -79,7 +79,7 @@ class LocalProcessManager implements ProcessManager {
 
   @override
   ProcessResult runSync(
-    covariant List<Object> command, {
+    List<Object> command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,

--- a/lib/src/interface/process_manager.dart
+++ b/lib/src/interface/process_manager.dart
@@ -83,9 +83,9 @@ abstract class ProcessManager {
   ///
   /// The default value for `mode` is `ProcessStartMode.normal`.
   Future<Process> start(
-    List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
+    List<Object> command, {
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
     ProcessStartMode mode = ProcessStartMode.normal,
@@ -136,9 +136,9 @@ abstract class ProcessManager {
   ///       stderr.write(result.stderr);
   ///     });
   Future<ProcessResult> run(
-    List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
+    List<Object> command, {
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
     Encoding stdoutEncoding = systemEncoding,
@@ -153,9 +153,9 @@ abstract class ProcessManager {
   /// Returns a `ProcessResult` with the result of running the process,
   /// i.e., exit code, standard out and standard in.
   ProcessResult runSync(
-    List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
+    List<Object> command, {
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
     Encoding stdoutEncoding = systemEncoding,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process
-version: 4.0.0
+version: 4.0.1
 description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 


### PR DESCRIPTION
When `LocalProcessManager.run`, `.runSync`, and `.start` were
migrated for null-safety, the base `ProcessManager` interface was not
updated.  This led to an inconsistency where the interface
unnecessarily required non-null versions of `workingDirectory` and
`environment`, which creates extra headache for clients.  This change
should be safe since it makes the base interface less restrictive.

Additionally, `LocalProcessManager` takes a covariant `List<Object>`
where the base interface takes `List<dynamic>`.  I don't see a need
for the interface to take `List<dynamic>` (which could accept `null`)
so change that too.  This change is less safe, although in practice
anything that attempted to pass `null` would already crash if using
the `LocalProcessManager` implementation anyway.

Fixes https://github.com/google/process.dart/issues/56.