### PR TITLE
Fix getExecutablePath to only return files that are actually readable and executable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 4.1.1
+
+* Fixed `getExecutablePath()` to only return path items that are
+  executable and readable to the user.
+
 #### 4.1.0
 
 * Fix the signatures of `ProcessManager.run`, `.runSync`, and `.start` to be

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process
-version: 4.1.0
+version: 4.1.1
 description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 
@@ -12,4 +12,4 @@ dependencies:
   platform: '^3.0.0'
 
 dev_dependencies:
-  test: ^1.16.0-nullsafety.8
+  test: ^1.16.8


### PR DESCRIPTION
If you have a file called "patch" (for instance), and it's mod 644 but in your path, the process.dart package will try and run it instead of the executable `/usr/bin/patch` in your path...

This PR fixes that, and adds a "real filesystem" test for that, since Dart doesn't have any way to manipulate file permissions in a virtual filesystem.