### PR TITLE
Fix ProcessManager.canRun to be consistent with LocalProcessManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 4.2.0
+
+* Fix the signatures of `ProcessManager.canRun` to be consistent with
+  `LocalProcessManager`.
+
 #### 4.1.1
 
 * Fixed `getExecutablePath()` to only return path items that are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #### 4.2.0
 
-* Fix the signatures of `ProcessManager.canRun` to be consistent with
+* Fix the signature of `ProcessManager.canRun` to be consistent with
   `LocalProcessManager`.
 
 #### 4.1.1

--- a/lib/src/interface/process_manager.dart
+++ b/lib/src/interface/process_manager.dart
@@ -163,7 +163,7 @@ abstract class ProcessManager {
   });
 
   /// Returns `true` if the [executable] exists and if it can be executed.
-  bool canRun(dynamic executable, {String workingDirectory});
+  bool canRun(dynamic executable, {String? workingDirectory});
 
   /// Kills the process with id [pid].
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process
-version: 4.1.1
+version: 4.2.0
 description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 


### PR DESCRIPTION
https://github.com/google/process.dart/pull/58 missed `canRun`.  I hit this when I tried to migrate Flutter tool's `ErrorHandlingProcessManager extends ProcessManager` to null safety.
https://github.com/flutter/flutter/blob/197b440e969841478d335d3fe5c6923bfb0e3a82/packages/flutter_tools/lib/src/base/error_handling_io.dart#L687