### PR TITLE
Add custom exceptions with more information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 4.2.1
+
+* Added custom exception types `ProcessPackageException` and
+  `ProcessPackageExecutableNotFoundException` to provide extra
+  information from exception conditions.
+
 #### 4.2.0
 
 * Fix the signature of `ProcessManager.canRun` to be consistent with

--- a/lib/process.dart
+++ b/lib/process.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/interface/exceptions.dart';
 export 'src/interface/local_process_manager.dart';
 export 'src/interface/process_manager.dart';
 export 'src/interface/process_wrapper.dart';

--- a/lib/src/interface/common.dart
+++ b/lib/src/interface/common.dart
@@ -78,7 +78,7 @@ String? getExecutablePath(
   }
 
   List<String> candidates = <String>[];
-  late List<String> searchPath;
+  List<String> searchPath;
   if (executable.contains(context.separator)) {
     // Deal with commands that specify a relative or absolute path differently.
     searchPath = <String>[workingDirectory];
@@ -117,18 +117,19 @@ String? getExecutablePath(
   if (throwOnFailure) {
     if (foundCandidates.isNotEmpty) {
       throw ProcessPackageExecutableNotFoundException(
-          executable,
-          message: 'Found candidates, but failed to resolve $executable to an executable.',
-          workingDirectory: workingDirectory,
-          candidates: candidates,
-          searchPath: searchPath,
+        executable,
+        message:
+            'Found candidates, but failed to resolve $executable to an executable.',
+        workingDirectory: workingDirectory,
+        candidates: candidates,
+        searchPath: searchPath,
       );
     } else {
       throw ProcessPackageExecutableNotFoundException(
-          executable,
-          message: 'Failed to resolve $executable to an executable.',
-          workingDirectory: workingDirectory,
-          searchPath: searchPath,
+        executable,
+        message: 'Failed to resolve $executable to an executable.',
+        workingDirectory: workingDirectory,
+        searchPath: searchPath,
       );
     }
   }

--- a/lib/src/interface/common.dart
+++ b/lib/src/interface/common.dart
@@ -119,15 +119,15 @@ String? getExecutablePath(
       throw ProcessPackageExecutableNotFoundException(
         executable,
         message:
-            'Found candidates, but failed to resolve $executable to an executable.',
+            'Found candidates, but lacked sufficient permissions to execute "$executable".',
         workingDirectory: workingDirectory,
-        candidates: candidates,
+        candidates: foundCandidates,
         searchPath: searchPath,
       );
     } else {
       throw ProcessPackageExecutableNotFoundException(
         executable,
-        message: 'Failed to resolve $executable to an executable.',
+        message: 'Failed to find "$executable" in the search path.',
         workingDirectory: workingDirectory,
         searchPath: searchPath,
       );

--- a/lib/src/interface/exceptions.dart
+++ b/lib/src/interface/exceptions.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io' show ProcessException;
+
+/// A specialized exception class for this package, so that it can throw
+/// customized exceptions with more information.
+class ProcessPackageException extends ProcessException {
+  /// Create a const ProcessPackageException.
+  ///
+  /// The [executable] should be the name of the executable to be run.
+  ///
+  /// The optional [workingDirectory] is the directory where the command
+  /// execution is attempted.
+  ///
+  /// The optional [arguments] is a list of the arguments to given to the
+  /// executable, already separated.
+  ///
+  /// The optional [message] is an additional message to be included in the
+  /// exception string when printed.
+  ///
+  /// The optional [errorCode] is the error code received when the executable
+  /// was run. Zero means it ran successfully, or that no error code was
+  /// available.
+  ///
+  /// See [ProcessException] for more information.
+  const ProcessPackageException(
+    String executable, {
+    List<String> arguments = const <String>[],
+    String message = "",
+    int errorCode = 0,
+    this.workingDirectory = '',
+  }) : super(executable, arguments, message, errorCode);
+
+  /// Creates a [ProcessPackageException] from a [ProcessException].
+  factory ProcessPackageException.fromProcessException(
+    ProcessException exception, {
+    String? workingDirectory,
+  }) {
+    return ProcessPackageException(
+      exception.executable,
+      arguments: exception.arguments,
+      message: exception.message,
+      errorCode: exception.errorCode,
+      workingDirectory: workingDirectory,
+    );
+  }
+
+  /// The optional working directory that the command was being executed in.
+  final String? workingDirectory;
+
+  // Don't implement a toString() for this exception, since code may be
+  // depending upon the format of ProcessException.toString().
+}
+
+/// An exception for when an executable is not found that was expected to be found.
+class ProcessPackageExecutableNotFoundException extends ProcessPackageException {
+  /// Creates a const ProcessPackageExecutableNotFoundException
+  ///
+  /// The optional [candidates] are the files matching the expected executable
+  /// on the [searchPath].
+  ///
+  /// The optional [searchPath] is the list of directories searched for the
+  /// expected executable.
+  ///
+  /// See [ProcessPackageException] for more information.
+  const ProcessPackageExecutableNotFoundException(
+    String executable, {
+    List<String> arguments = const <String>[],
+    String message = "",
+    int errorCode = 0,
+    String workingDirectory = '',
+    this.candidates = const <String>[],
+    this.searchPath = const <String>[],
+  }) : super(
+          executable,
+          arguments: arguments,
+          message: message,
+          errorCode: errorCode,
+          workingDirectory: workingDirectory,
+        );
+
+  /// The list of non-viable executable candidates found.
+  final List<String> candidates;
+
+  /// The search path used to find candidates.
+  final List<String> searchPath;
+
+  @override
+  String toString() {
+    StringBuffer buffer = StringBuffer('$runtimeType: $message');
+    // Don't add an extra space if there are no arguments.
+    final String args = arguments.isNotEmpty ? ' ${arguments.join(' ')}' : '';
+    buffer.writeln('  Command: $executable$args');
+    if (workingDirectory != null && workingDirectory!.isNotEmpty) {
+      buffer.writeln('  Working Directory: $workingDirectory');
+    }
+    if (candidates.isNotEmpty) {
+      buffer.writeln('  Candidates:\n    ${candidates.join('\n    ')}');
+    }
+    buffer.writeln('  Search Path:\n    ${searchPath.join('\n    ')}');
+    return buffer.toString();
+  }
+}

--- a/lib/src/interface/exceptions.dart
+++ b/lib/src/interface/exceptions.dart
@@ -30,7 +30,7 @@ class ProcessPackageException extends ProcessException {
     List<String> arguments = const <String>[],
     String message = "",
     int errorCode = 0,
-    this.workingDirectory = '',
+    this.workingDirectory,
   }) : super(executable, arguments, message, errorCode);
 
   /// Creates a [ProcessPackageException] from a [ProcessException].
@@ -71,7 +71,7 @@ class ProcessPackageExecutableNotFoundException
     List<String> arguments = const <String>[],
     String message = "",
     int errorCode = 0,
-    String workingDirectory = '',
+    String? workingDirectory,
     this.candidates = const <String>[],
     this.searchPath = const <String>[],
   }) : super(
@@ -90,7 +90,7 @@ class ProcessPackageExecutableNotFoundException
 
   @override
   String toString() {
-    StringBuffer buffer = StringBuffer('$runtimeType: $message');
+    StringBuffer buffer = StringBuffer('$runtimeType: $message\n');
     // Don't add an extra space if there are no arguments.
     final String args = arguments.isNotEmpty ? ' ${arguments.join(' ')}' : '';
     buffer.writeln('  Command: $executable$args');

--- a/lib/src/interface/exceptions.dart
+++ b/lib/src/interface/exceptions.dart
@@ -55,7 +55,8 @@ class ProcessPackageException extends ProcessException {
 }
 
 /// An exception for when an executable is not found that was expected to be found.
-class ProcessPackageExecutableNotFoundException extends ProcessPackageException {
+class ProcessPackageExecutableNotFoundException
+    extends ProcessPackageException {
   /// Creates a const ProcessPackageExecutableNotFoundException
   ///
   /// The optional [candidates] are the files matching the expected executable

--- a/lib/src/interface/local_process_manager.dart
+++ b/lib/src/interface/local_process_manager.dart
@@ -139,8 +139,11 @@ String _getExecutable(
   if (runInShell) {
     return commandName;
   }
-  return getExecutablePath(commandName, workingDirectory,
-      throwOnFailure: true)!;
+  return getExecutablePath(
+    commandName,
+    workingDirectory,
+    throwOnFailure: true,
+  )!;
 }
 
 List<String> _getArguments(List<Object> command) =>

--- a/lib/src/interface/local_process_manager.dart
+++ b/lib/src/interface/local_process_manager.dart
@@ -55,7 +55,8 @@ class LocalProcessManager implements ProcessManager {
         mode: mode,
       );
     } on ProcessException catch (exception) {
-      throw ProcessPackageException.fromProcessException(exception, workingDirectory: workingDirectory);
+      throw ProcessPackageException.fromProcessException(exception,
+          workingDirectory: workingDirectory);
     }
   }
 
@@ -85,7 +86,8 @@ class LocalProcessManager implements ProcessManager {
         stderrEncoding: stderrEncoding,
       );
     } on ProcessException catch (exception) {
-      throw ProcessPackageException.fromProcessException(exception, workingDirectory: workingDirectory);
+      throw ProcessPackageException.fromProcessException(exception,
+          workingDirectory: workingDirectory);
     }
   }
 
@@ -115,7 +117,8 @@ class LocalProcessManager implements ProcessManager {
         stderrEncoding: stderrEncoding,
       );
     } on ProcessException catch (exception) {
-      throw ProcessPackageException.fromProcessException(exception, workingDirectory: workingDirectory);
+      throw ProcessPackageException.fromProcessException(exception,
+          workingDirectory: workingDirectory);
     }
   }
 
@@ -136,7 +139,8 @@ String _getExecutable(
   if (runInShell) {
     return commandName;
   }
-  return getExecutablePath(commandName, workingDirectory, throwOnFailure: true)!;
+  return getExecutablePath(commandName, workingDirectory,
+      throwOnFailure: true)!;
 }
 
 List<String> _getArguments(List<Object> command) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: process
-version: 4.2.0
+version: 4.2.1
 description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 

--- a/test/src/interface/common_test.dart
+++ b/test/src/interface/common_test.dart
@@ -370,6 +370,9 @@ void main() {
     });
   });
   group('Real Filesystem', () {
+    // These tests don't use the memory filesystem because Dart can't modify file
+    // executable permissions, so we have to create them with actual commands.
+
     late Platform platform;
     late Directory tmpDir;
     late Directory pathDir1;
@@ -416,8 +419,6 @@ void main() {
       tmpDir.deleteSync(recursive: true);
     });
 
-    // This doesn't use the memory filesystem because Dart can't modify file
-    // executable permissions, so we have to create them with actual commands.
     test('Only returns executables in PATH', () {
       if (localPlatform.isWindows) {
         // Windows doesn't check for executable-ness, and we can't run 'chmod'
@@ -448,6 +449,73 @@ void main() {
       // one comes last in the PATH, but is the only one executable by the
       // user.
       _expectSamePath(executablePath, command5.absolute.path);
+    });
+
+    test(
+        'Test that finding non-executable paths throws with proper information',
+        () {
+      if (localPlatform.isWindows) {
+        // Windows doesn't check for executable-ness, and we can't run 'chmod'
+        // on Windows anyhow.
+        return;
+      }
+
+      // Make the second command in the path executable, but not the first.
+      // No executable permissions
+      io.Process.runSync("chmod", <String>["0644", "--", command1.path]);
+      // Only group executable permissions
+      io.Process.runSync("chmod", <String>["0645", "--", command2.path]);
+      // Only other executable permissions
+      io.Process.runSync("chmod", <String>["0654", "--", command3.path]);
+      // All executable permissions, but not readable
+      io.Process.runSync("chmod", <String>["0311", "--", command4.path]);
+
+      io.ProcessException error;
+      try {
+        getExecutablePath(
+          'command',
+          tmpDir.path,
+          platform: platform,
+          fs: fs,
+          throwOnFailure: true,
+        );
+        fail('Expected to throw');
+      } on io.ProcessException catch (err) {
+        error = err;
+      }
+
+      expect(error, isA<ProcessPackageExecutableNotFoundException>());
+      ProcessPackageExecutableNotFoundException notFoundException =
+          error as ProcessPackageExecutableNotFoundException;
+      expect(
+          notFoundException.candidates,
+          equals(<String>[
+            '${tmpDir.path}/path1/command',
+            '${tmpDir.path}/path2/command',
+            '${tmpDir.path}/path3/command',
+            '${tmpDir.path}/path4/command',
+            '${tmpDir.path}/path5/command',
+          ]));
+      expect(
+        error.toString(),
+        equals(
+          'ProcessPackageExecutableNotFoundException: Found candidates, but lacked sufficient permissions to execute "command".\n'
+          '  Command: command\n'
+          '  Working Directory: ${tmpDir.path}\n'
+          '  Candidates:\n'
+          '    ${tmpDir.path}/path1/command\n'
+          '    ${tmpDir.path}/path2/command\n'
+          '    ${tmpDir.path}/path3/command\n'
+          '    ${tmpDir.path}/path4/command\n'
+          '    ${tmpDir.path}/path5/command\n'
+          '  Search Path:\n'
+          '    ${tmpDir.path}/path1\n'
+          '    ${tmpDir.path}/path2\n'
+          '    ${tmpDir.path}/path3\n'
+          '    ${tmpDir.path}/path4\n'
+          '    ${tmpDir.path}/path5\n',
+        ),
+      );
     });
   });
 }

--- a/test/src/interface/common_test.dart
+++ b/test/src/interface/common_test.dart
@@ -517,6 +517,47 @@ void main() {
         ),
       );
     });
+
+    test('Test that finding no executable paths throws with proper information',
+        () {
+      if (localPlatform.isWindows) {
+        // Windows doesn't check for executable-ness, and we can't run 'chmod'
+        // on Windows anyhow.
+        return;
+      }
+
+      io.ProcessException error;
+      try {
+        getExecutablePath(
+          'non-existent-command',
+          tmpDir.path,
+          platform: platform,
+          fs: fs,
+          throwOnFailure: true,
+        );
+        fail('Expected to throw');
+      } on io.ProcessException catch (err) {
+        error = err;
+      }
+
+      expect(error, isA<ProcessPackageExecutableNotFoundException>());
+      ProcessPackageExecutableNotFoundException notFoundException =
+          error as ProcessPackageExecutableNotFoundException;
+      expect(notFoundException.candidates, isEmpty);
+      expect(
+        error.toString(),
+        equals(
+            'ProcessPackageExecutableNotFoundException: Failed to find "non-existent-command" in the search path.\n'
+            '  Command: non-existent-command\n'
+            '  Working Directory: ${tmpDir.path}\n'
+            '  Search Path:\n'
+            '    ${tmpDir.path}/path1\n'
+            '    ${tmpDir.path}/path2\n'
+            '    ${tmpDir.path}/path3\n'
+            '    ${tmpDir.path}/path4\n'
+            '    ${tmpDir.path}/path5\n'),
+      );
+    });
   });
 }
 

--- a/test/src/interface/common_test.dart
+++ b/test/src/interface/common_test.dart
@@ -4,10 +4,10 @@
 
 import 'dart:io' as io;
 import 'package:file/local.dart';
-import 'package:path/path.dart' as path;
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:platform/platform.dart';
+import 'package:process/process.dart';
 import 'package:process/src/interface/common.dart';
 import 'package:test/test.dart';
 
@@ -195,27 +195,33 @@ void main() {
         expect(executablePath, isNull);
       });
 
-      test('not found with errorOnNull throws exception with match state', () {
+      test('not found with throwOnFailure throws exception with match state', () {
         String command = 'foo.exe';
-        dynamic error;
+        io.ProcessException error;
         try {
           getExecutablePath(
             command,
             workingDir.path,
             platform: platform,
             fs: fs,
-            errorOnNull: true,
+            throwOnFailure: true,
           );
           fail('Expected to throw');
-        } catch (err) {
+        } on io.ProcessException catch (err) {
           error = err;
         }
 
-        expect(error, isA<ArgumentError>());
+        expect(error, isA<ProcessPackageExecutableNotFoundException>());
+        ProcessPackageExecutableNotFoundException notFoundException = error as ProcessPackageExecutableNotFoundException;
+        expect(notFoundException.candidates, isEmpty);
+        expect(notFoundException.workingDirectory, equals(workingDir.path));
         expect(
             error.toString(),
             contains(
-                'workingDirectory: C:\\.tmp_rand0\\work_dir_rand0, candidates: 2'));
+              '  Working Directory: C:\\.tmp_rand0\\work_dir_rand0\n'
+              '  Search Path:\n'
+              '    C:\\.tmp_rand0\\dir1_rand0\n'
+              '    C:\\.tmp_rand0\\dir2_rand0\n'));
       });
 
       test('when path has spaces', () {
@@ -324,27 +330,33 @@ void main() {
         expect(executablePath, isNull);
       });
 
-      test('not found with errorOnNull throws exception with match state', () {
+      test('not found with throwOnFailure throws exception with match state', () {
         String command = 'foo';
-        dynamic error;
+        io.ProcessException error;
         try {
           getExecutablePath(
             command,
             workingDir.path,
             platform: platform,
             fs: fs,
-            errorOnNull: true,
+            throwOnFailure: true,
           );
           fail('Expected to throw');
-        } catch (err) {
+        } on io.ProcessException catch (err) {
           error = err;
         }
 
-        expect(error, isA<ArgumentError>());
+        expect(error, isA<ProcessPackageExecutableNotFoundException>());
+        ProcessPackageExecutableNotFoundException notFoundException = error as ProcessPackageExecutableNotFoundException;
+        expect(notFoundException.candidates, isEmpty);
+        expect(notFoundException.workingDirectory, equals(workingDir.path));
         expect(
             error.toString(),
             contains(
-                'workingDirectory: /.tmp_rand0/work_dir_rand0, candidates: 2'));
+              '  Working Directory: /.tmp_rand0/work_dir_rand0\n'
+              '  Search Path:\n'
+              '    /.tmp_rand0/dir1_rand0\n'
+              '    /.tmp_rand0/dir2_rand0\n'));
       });
 
       test('when path has spaces', () {

--- a/test/src/interface/common_test.dart
+++ b/test/src/interface/common_test.dart
@@ -195,7 +195,8 @@ void main() {
         expect(executablePath, isNull);
       });
 
-      test('not found with throwOnFailure throws exception with match state', () {
+      test('not found with throwOnFailure throws exception with match state',
+          () {
         String command = 'foo.exe';
         io.ProcessException error;
         try {
@@ -212,16 +213,16 @@ void main() {
         }
 
         expect(error, isA<ProcessPackageExecutableNotFoundException>());
-        ProcessPackageExecutableNotFoundException notFoundException = error as ProcessPackageExecutableNotFoundException;
+        ProcessPackageExecutableNotFoundException notFoundException =
+            error as ProcessPackageExecutableNotFoundException;
         expect(notFoundException.candidates, isEmpty);
         expect(notFoundException.workingDirectory, equals(workingDir.path));
         expect(
             error.toString(),
-            contains(
-              '  Working Directory: C:\\.tmp_rand0\\work_dir_rand0\n'
-              '  Search Path:\n'
-              '    C:\\.tmp_rand0\\dir1_rand0\n'
-              '    C:\\.tmp_rand0\\dir2_rand0\n'));
+            contains('  Working Directory: C:\\.tmp_rand0\\work_dir_rand0\n'
+                '  Search Path:\n'
+                '    C:\\.tmp_rand0\\dir1_rand0\n'
+                '    C:\\.tmp_rand0\\dir2_rand0\n'));
       });
 
       test('when path has spaces', () {
@@ -330,7 +331,8 @@ void main() {
         expect(executablePath, isNull);
       });
 
-      test('not found with throwOnFailure throws exception with match state', () {
+      test('not found with throwOnFailure throws exception with match state',
+          () {
         String command = 'foo';
         io.ProcessException error;
         try {
@@ -347,16 +349,16 @@ void main() {
         }
 
         expect(error, isA<ProcessPackageExecutableNotFoundException>());
-        ProcessPackageExecutableNotFoundException notFoundException = error as ProcessPackageExecutableNotFoundException;
+        ProcessPackageExecutableNotFoundException notFoundException =
+            error as ProcessPackageExecutableNotFoundException;
         expect(notFoundException.candidates, isEmpty);
         expect(notFoundException.workingDirectory, equals(workingDir.path));
         expect(
             error.toString(),
-            contains(
-              '  Working Directory: /.tmp_rand0/work_dir_rand0\n'
-              '  Search Path:\n'
-              '    /.tmp_rand0/dir1_rand0\n'
-              '    /.tmp_rand0/dir2_rand0\n'));
+            contains('  Working Directory: /.tmp_rand0/work_dir_rand0\n'
+                '  Search Path:\n'
+                '    /.tmp_rand0/dir1_rand0\n'
+                '    /.tmp_rand0/dir2_rand0\n'));
       });
 
       test('when path has spaces', () {

--- a/test/src/interface/process_wrapper_test.dart
+++ b/test/src/interface/process_wrapper_test.dart
@@ -80,30 +80,6 @@ void main() {
         await testStream(process.stderr, delegate.stderrController, 'stderr');
       });
     });
-
-    group('exceptions', () {
-      late bool done;
-
-      setUp(() {
-        done = false;
-        // ignore: unawaited_futures
-        process.done.then((int result) {
-          done = true;
-        });
-      });
-
-      test('works in conjunction with subscribers to stdio streams', () async {
-        process.stdout
-            .transform<String>(utf8.decoder)
-            .transform<String>(const LineSplitter())
-            .listen(print);
-        delegate.exitCodeCompleter.complete(0);
-        await delegate.stdoutController.close();
-        await delegate.stderrController.close();
-        await Future<void>.value();
-        expect(done, isTrue);
-      });
-    });
   });
 }
 

--- a/test/src/interface/process_wrapper_test.dart
+++ b/test/src/interface/process_wrapper_test.dart
@@ -80,6 +80,31 @@ void main() {
         await testStream(process.stderr, delegate.stderrController, 'stderr');
       });
     });
+
+    group('exceptions', () {
+      late bool done;
+
+      setUp(() {
+        done = false;
+        // ignore: unawaited_futures
+        process.done.then((int result) {
+          done = true;
+        });
+      });
+
+      test('works in conjunction with subscribers to stdio streams', () async {
+        process.stdout
+            .transform<String>(utf8.decoder)
+            .transform<String>(const LineSplitter())
+            .listen(print);
+        delegate.exitCodeCompleter.complete(0);
+        await delegate.stdoutController.close();
+        await delegate.stderrController.close();
+        await Future<void>.value();
+        expect(done, isTrue);
+      });
+
+    });
   });
 }
 

--- a/test/src/interface/process_wrapper_test.dart
+++ b/test/src/interface/process_wrapper_test.dart
@@ -103,7 +103,6 @@ void main() {
         await Future<void>.value();
         expect(done, isTrue);
       });
-
     });
   });
 }


### PR DESCRIPTION
This adds two custom exception classes to the package, `ProcessPackageException` and `ProcessPackageExectuableNotFoundException`, both of which are subclasses of `dart:io`'s `ProcessException`.

Exceptions thrown when calling `LocalProcessManager` methods will now be converted to `ProcessPackageException`s to add additional information to the exception. There is no `toString` implemented for `ProcessPackageExcepion`, so that it won't break code that depends on the format. It  adds information about the working directory when the command was attempted.

The non-exported `getExecutablePath` function will now throw a `ProcessPackageExectuableNotFoundException` with additional information so that it can be distinguished whether a command was simply not found, or if an unsuitable candidate was found. The exception includes information about the candidates found, as well as the search path used. I also changed the argument called `errorOnNull` to `throwOnFailure`, since name was confusing. It's not an exported function, so this should be an acceptable breakage.

/cc @jonahwilliams 