### PR TITLE
Make encoding parameter nullable (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 4.2.4
+
+* Mark `stderrEncoding` and `stdoutEncoding` parameters as nullable again,
+  now that the upstream SDK issue has been fixed.
+
 #### 4.2.3
 
 * Rollback to version 4.2.1 (https://github.com/google/process.dart/issues/64)

--- a/lib/src/interface/local_process_manager.dart
+++ b/lib/src/interface/local_process_manager.dart
@@ -12,8 +12,6 @@ import 'dart:io'
         ProcessException,
         systemEncoding;
 
-import 'package:process/process.dart';
-
 import 'common.dart';
 import 'exceptions.dart';
 import 'process_manager.dart';

--- a/lib/src/interface/local_process_manager.dart
+++ b/lib/src/interface/local_process_manager.dart
@@ -67,8 +67,8 @@ class LocalProcessManager implements ProcessManager {
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
-    Encoding stdoutEncoding = systemEncoding,
-    Encoding stderrEncoding = systemEncoding,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
   }) {
     try {
       return Process.run(
@@ -98,8 +98,8 @@ class LocalProcessManager implements ProcessManager {
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
-    Encoding stdoutEncoding = systemEncoding,
-    Encoding stderrEncoding = systemEncoding,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
   }) {
     try {
       return Process.runSync(

--- a/lib/src/interface/process_manager.dart
+++ b/lib/src/interface/process_manager.dart
@@ -141,8 +141,9 @@ abstract class ProcessManager {
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
-    Encoding stdoutEncoding = systemEncoding,
-    Encoding stderrEncoding = systemEncoding,
+    // TODO(#64): Remove the `covariant` keyword.
+    covariant Encoding? stdoutEncoding = systemEncoding,
+    covariant Encoding? stderrEncoding = systemEncoding,
   });
 
   /// Starts a process and runs it to completion. This is a synchronous
@@ -158,8 +159,9 @@ abstract class ProcessManager {
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
-    Encoding stdoutEncoding = systemEncoding,
-    Encoding stderrEncoding = systemEncoding,
+    // TODO(#64): Remove the `covariant` keyword.
+    covariant Encoding? stdoutEncoding = systemEncoding,
+    covariant Encoding? stderrEncoding = systemEncoding,
   });
 
   /// Returns `true` if the [executable] exists and if it can be executed.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: process
-version: 4.2.3
+version: 4.2.4
 description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.14.0-0 <3.0.0'
 
 dependencies:
   file: '^6.0.0'


### PR DESCRIPTION
Re-do of #65.

Require Dart SDK >= 2.14.0, as that's the first release to include the needed fix (dart-lang/sdk@5de7dfb90bf1d006c64992938a9e2a2a0908d4d4).

cc #64