### PR TITLE
chore: bump depedencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.14.0-0 <4.0.0'
 
 dependencies:
-  file: '^7.0.0'
+  file: '>=6.0.0 <8.0.0'
   path: ^1.8.0
   platform: '^3.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,13 +4,13 @@ description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 
 environment:
-  sdk: '>=2.14.0-0 <3.0.0'
+  sdk: '>=2.14.0-0 <4.0.0'
 
 dependencies:
-  file: '^6.0.0'
+  file: '^7.0.0'
   path: ^1.8.0
   platform: '^3.0.0'
 
 dev_dependencies:
-  lints: ^1.0.1
+  lints: ^2.1.0
   test: ^1.16.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,5 +12,5 @@ dependencies:
   platform: '^3.0.0'
 
 dev_dependencies:
-  lints: ^2.1.0
+  lints: '>=1.0.1 <3.0.0'
   test: ^1.16.8


### PR DESCRIPTION
Upgrade project dependencies, blocking other packages that also depend on it to upgrade (e.g. `melos` and `dart_code_metrics` via `pub_updater`)

Also bump the SDK version to <4.0.0

All test passed.