### PR TITLE
Bump dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 5.0.1
+
+* Update dependencies to work on Dart 3.
+
 #### 5.0.0
 
 * Remove the `covariant` keyword from `stderrEncoding` and `stdoutEncoding`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: process
-version: 5.0.0
+version: 5.0.1
 description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 
 environment:
-  sdk: '>=2.14.0-0 <3.0.0'
+  sdk: '>=2.14.0-0 <4.0.0'
 
 dependencies:
-  file: '^6.0.0'
+  file: '>=6.0.0 <8.0.0'
   path: ^1.8.0
   platform: '^3.0.0'
 
 dev_dependencies:
-  lints: ^1.0.1
+  lints: '>=1.0.1 <3.0.0'
   test: ^1.16.8


### PR DESCRIPTION
Sequel / Fix https://github.com/google/process.dart/pull/75.
I added the minor changelog version and kept the author as co-author.
cc @gspencergoog.