### PR TITLE
Bump min SDK version to non-prerelease version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Remove the `covariant` keyword from `stderrEncoding` and `stdoutEncoding`
   parameters.
 * Update dependencies to work on Dart 3.
+* Bumped min SDK dependency to nearest non-prerelease version (2.14.0)
 
 #### 4.2.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A pluggable, mockable process invocation abstraction for Dart.
 homepage: https://github.com/google/process.dart
 
 environment:
-  sdk: '>=2.14.0-0 <4.0.0'
+  sdk: '>=2.14.0 <4.0.0'
 
 dependencies:
   file: '>=6.0.0 <8.0.0'


### PR DESCRIPTION
The old min SDK constraint was a pre-release version, which causes a warning when publishing.  This just removes the '-0' and bumps it to the next version (2.14.0).